### PR TITLE
Update to VisualStudioHelper.cs to fix parsing of solutions items

### DIFF
--- a/Zbu.ModelsBuilder.CustomTool/VisualStudio/VisualStudioHelper.cs
+++ b/Zbu.ModelsBuilder.CustomTool/VisualStudio/VisualStudioHelper.cs
@@ -41,6 +41,7 @@ namespace Zbu.ModelsBuilder.CustomTool.VisualStudio
             uint itemId = 0;
             var vsProject = dte.Solution.Projects
                 .Cast<EnvDTE.Project>()
+                .Where(p => !p.Kind.Equals(EnvDTE.Constants.vsProjectKindSolutionItems))
                 .Select(ToHierarchy)
                 .Cast<IVsProject>()
                 .FirstOrDefault(x =>
@@ -88,7 +89,7 @@ namespace Zbu.ModelsBuilder.CustomTool.VisualStudio
 
         private static IVsHierarchy ToHierarchy(EnvDTE.Project project)
         {
-            if (project == null)
+            if (project == null || string.IsNullOrWhiteSpace(project.FileName))
                 throw new ArgumentNullException("project");
 
             string projectGuid = null;


### PR DESCRIPTION
Added code to filter out solution items when finding a solution's project files and also a check to make sure we have a file name when loading a project file.