### PR TITLE
Change to property summary to make descriptions easier to read

### DIFF
--- a/Zbu.ModelsBuilder/Building/TextBuilder.cs
+++ b/Zbu.ModelsBuilder/Building/TextBuilder.cs
@@ -238,11 +238,10 @@ namespace Zbu.ModelsBuilder.Building
             {
                 sb.Append("\t\t///<summary>\n");
 
-                if (!string.IsNullOrWhiteSpace(property.Name))
-                    sb.AppendFormat("\t\t///{0}\n", XmlCommentString(property.Name));
-
                 if (!string.IsNullOrWhiteSpace(property.Description))
-                    sb.AppendFormat("\t\t///{0}\n", XmlCommentString(property.Description));
+                    sb.AppendFormat("\t\t/// {0}: {1}\n", XmlCommentString(property.Name), XmlCommentString(property.Description));
+                else
+                    sb.AppendFormat("\t\t/// {0}\n", XmlCommentString(property.Name));
 
                 sb.Append("\t\t///</summary>\n");
             }
@@ -271,12 +270,11 @@ namespace Zbu.ModelsBuilder.Building
             if (!string.IsNullOrWhiteSpace(property.Name) || !string.IsNullOrWhiteSpace(property.Description))
             {
                 sb.Append("\t\t///<summary>\n");
-
-                if (!string.IsNullOrWhiteSpace(property.Name))
-                    sb.AppendFormat("\t\t///{0}\n", XmlCommentString(property.Name));
-
+                
                 if (!string.IsNullOrWhiteSpace(property.Description))
-                    sb.AppendFormat("\t\t///{0}\n", XmlCommentString(property.Description));
+                    sb.AppendFormat("\t\t/// {0}: {1}\n", XmlCommentString(property.Name), XmlCommentString(property.Description));
+                else
+                    sb.AppendFormat("\t\t/// {0}\n", XmlCommentString(property.Name));
 
                 sb.Append("\t\t///</summary>\n");
             }


### PR DESCRIPTION
Pull request #65 allowed property descriptions to be viewed in a property's XML summary. This pull request tweaks the layout of the XML summary for each property so that when using Visual Studio's IntelliSense, the property name and property description are clearly defined.