### PR TITLE
Strong Typed GetPropertyValue methods.

### DIFF
--- a/Umbraco.ModelsBuilder/Building/TextBuilder.cs
+++ b/Umbraco.ModelsBuilder/Building/TextBuilder.cs
@@ -197,6 +197,23 @@ namespace Umbraco.ModelsBuilder.Building
                 type.ClrName);
             sb.Append("\t\t{\n\t\t\treturn PublishedContentModelUtility.GetModelPropertyType(GetModelContentType(), selector);\n\t\t}\n");
 
+            // write out strong type GetPropertyValue methods
+            sb.AppendFormat("\t\tpublic TValue GetPropertyValue<TValue>(Expression<Func<{0}, TValue>> selector)\n",
+                type.ClrName);
+            sb.Append("\t\t{\n\t\t\treturn this.GetPropertyValue<TValue>(PublishedContentModelUtility.GetModelPropertyAlias(selector));\n\t\t}\n");
+
+            sb.AppendFormat("\t\tpublic TValue GetPropertyValue<TValue>(Expression<Func<{0}, TValue>> selector, bool recurse)\n",
+                type.ClrName);
+            sb.Append("\t\t{\n\t\t\treturn this.GetPropertyValue<TValue>(PublishedContentModelUtility.GetModelPropertyAlias(selector), recurse);\n\t\t}\n");
+
+            sb.AppendFormat("\t\tpublic TValue GetPropertyValue<TValue>(Expression<Func<{0}, TValue>> selector, TValue defaultValue)\n",
+                type.ClrName);
+            sb.Append("\t\t{\n\t\t\treturn this.GetPropertyValue<TValue>(PublishedContentModelUtility.GetModelPropertyAlias(selector), defaultValue);\n\t\t}\n");
+
+            sb.AppendFormat("\t\tpublic TValue GetPropertyValue<TValue>(Expression<Func<{0}, TValue>> selector, bool recurse, TValue defaultValue)\n",
+                type.ClrName);
+            sb.Append("\t\t{\n\t\t\treturn this.GetPropertyValue<TValue>(PublishedContentModelUtility.GetModelPropertyAlias(selector), recurse, defaultValue);\n\t\t}\n");
+
             // write the properties
             WriteContentTypeProperties(sb, type);
 

--- a/Umbraco.ModelsBuilder/Umbraco/PublishedContentModelUtility.cs
+++ b/Umbraco.ModelsBuilder/Umbraco/PublishedContentModelUtility.cs
@@ -26,6 +26,12 @@ namespace Umbraco.ModelsBuilder.Umbraco
         public static PublishedPropertyType GetModelPropertyType<TModel, TValue>(PublishedContentType contentType, Expression<Func<TModel, TValue>> selector)
             where TModel : PublishedContentModel
         {
+            return contentType.GetPropertyType(GetModelPropertyAlias(selector));
+        }
+
+        public static string GetModelPropertyAlias<TModel, TValue>(Expression<Func<TModel, TValue>> selector)
+            where TModel : PublishedContentModel
+        {
             var expr = selector.Body as MemberExpression;
 
             if (expr == null)
@@ -35,14 +41,14 @@ namespace Umbraco.ModelsBuilder.Umbraco
             // see note above : accepted risk...
 
             var attr = expr.Member
-                .GetCustomAttributes(typeof (ImplementPropertyTypeAttribute), false)
+                .GetCustomAttributes(typeof(ImplementPropertyTypeAttribute), false)
                 .OfType<ImplementPropertyTypeAttribute>()
                 .SingleOrDefault();
 
             if (string.IsNullOrWhiteSpace(attr?.Alias))
                 throw new InvalidOperationException($"Could not figure out property alias for property \"{expr.Member.Name}\".");
 
-            return contentType.GetPropertyType(attr.Alias);
+            return attr.Alias;
         }
     }
 }


### PR DESCRIPTION
This adds strong typed GetPropertyValue methods to all generated models so that developers can do the following:

@Model.Content.GetPropertyValue(s => s.BannerImage, true)
@Model.Content.GetPropertyValue(s => s.BannerImage, "someOtherImage.gif")
@Model.Content.GetProeprtyValue(s => s.BannerImage, Model.Content.AlternateImage)