### PR TITLE
Removed type id from comments

### DIFF
--- a/Umbraco.ModelsBuilder.Tests/BuilderTests.cs
+++ b/Umbraco.ModelsBuilder.Tests/BuilderTests.cs
@@ -1298,7 +1298,7 @@ using Umbraco.ModelsBuilder.Umbraco;
 
 namespace Umbraco.Web.PublishedContentModels
 {
-	// Mixin content Type 1 with alias ""type1""
+	// Mixin content type with alias ""type1""
 	public partial interface IType1 : IPublishedContent
 	{
 		string Prop1a { get; }
@@ -1703,7 +1703,7 @@ using Umbraco.ModelsBuilder.Umbraco;
 
 namespace Umbraco.Web.PublishedContentModels
 {
-	// Content Type 1 with alias ""type1""
+	// Content type with alias ""type1""
 	[PublishedContentModel(""type1"")]
 	public partial class Type2 : PublishedContentModel
 	{

--- a/Umbraco.ModelsBuilder.Tests/SampleGeneratedCode.cs
+++ b/Umbraco.ModelsBuilder.Tests/SampleGeneratedCode.cs
@@ -17,7 +17,7 @@ using Umbraco.Web;
 
 namespace Umbraco.ModelsBuilder.Tests.Models
 {
-    // Content Type 1044 with alias "page"
+    // Content type with alias "page"
     public partial class Page : PublishedContentModel
     {
         public Page(IPublishedContent content)
@@ -55,7 +55,7 @@ namespace Umbraco.ModelsBuilder.Tests.Models
         }
     }
 
-    // Content Type 1059 with alias "AnotherPage"
+    // Content type with alias "AnotherPage"
     public partial class AnotherPage : PublishedContentModel
     {
         public AnotherPage(IPublishedContent content)
@@ -73,7 +73,7 @@ namespace Umbraco.ModelsBuilder.Tests.Models
         }
     }
 
-    // Content Type 1068 with alias "loskDalmosk"
+    // Content type with alias "loskDalmosk"
     public partial class LoskDalmosk : PublishedContentModel
     {
         public LoskDalmosk(IPublishedContent content)
@@ -81,7 +81,7 @@ namespace Umbraco.ModelsBuilder.Tests.Models
         { }
     }
 
-    // Content Type 2078 with alias "parentDoc"
+    // Content type with alias "parentDoc"
     public partial class ParentDoc : PublishedContentModel
     {
         public ParentDoc(IPublishedContent content)
@@ -94,7 +94,7 @@ namespace Umbraco.ModelsBuilder.Tests.Models
         }
     }
 
-    // Content Type 2079 with alias "childDoc"
+    // Content type with alias "childDoc"
     public partial class ChildDoc : ParentDoc
     {
         public ChildDoc(IPublishedContent content)
@@ -107,7 +107,7 @@ namespace Umbraco.ModelsBuilder.Tests.Models
         }
     }
 
-    // Content Type 2087 with alias "aaa"
+    // Content type with alias "aaa"
     public partial class Aaa : ParentDoc
     {
         public Aaa(IPublishedContent content)
@@ -115,7 +115,7 @@ namespace Umbraco.ModelsBuilder.Tests.Models
         { }
     }
 
-    // Content Type 2091 with alias "CrazyCTypeAlias"
+    // Content type with alias "CrazyCTypeAlias"
     public partial class CrazyCTypeAlias : PublishedContentModel
     {
         public CrazyCTypeAlias(IPublishedContent content)
@@ -123,7 +123,7 @@ namespace Umbraco.ModelsBuilder.Tests.Models
         { }
     }
 
-    // Content Type 4092 with alias "RtePage"
+    // Content type with alias "RtePage"
     public partial class RtePage : PublishedContentModel
     {
         public RtePage(IPublishedContent content)
@@ -141,7 +141,7 @@ namespace Umbraco.ModelsBuilder.Tests.Models
         }
     }
 
-    // Content Type 5101 with alias "SubRtePage"
+    // Content type with alias "SubRtePage"
     public partial class SubRtePage : RtePage
     {
         public SubRtePage(IPublishedContent content)
@@ -149,7 +149,7 @@ namespace Umbraco.ModelsBuilder.Tests.Models
         { }
     }
 
-    // Content Type 6104 with alias "bbb"
+    // Content type with alias "bbb"
     public partial class SpecialBbb : ParentDoc, IMixinTestRenamed
     {
         public SpecialBbb(IPublishedContent content)
@@ -162,13 +162,13 @@ namespace Umbraco.ModelsBuilder.Tests.Models
         }
     }
 
-    // Mixin content Type 6105 with alias "MixinTest"
+    // Mixin content type with alias "MixinTest"
     public partial interface IMixinTestRenamed : IPublishedContent
     {
         string MixinProp { get; }
     }
 
-    // Content Type 6105 with alias "MixinTest"
+    // Content type with alias "MixinTest"
     public partial class MixinTestRenamed : PublishedContentModel, IMixinTestRenamed
     {
         public MixinTestRenamed(IPublishedContent content)

--- a/Umbraco.ModelsBuilder/Building/CodeDomBuilder.cs
+++ b/Umbraco.ModelsBuilder/Building/CodeDomBuilder.cs
@@ -43,7 +43,7 @@ namespace Umbraco.ModelsBuilder.Building
                 foreach (var mixinType in typeModel.DeclaringInterfaces)
                     i.BaseTypes.Add(mixinType.ClrName);
 
-                i.Comments.Add(new CodeCommentStatement($"Mixin content Type {typeModel.Id} with alias \"{typeModel.Alias}\""));
+                i.Comments.Add(new CodeCommentStatement($"Mixin content type with alias \"{typeModel.Alias}\""));
 
                 foreach (var propertyModel in typeModel.Properties)
                 {
@@ -81,7 +81,7 @@ namespace Umbraco.ModelsBuilder.Building
             foreach (var mixin in typeModel.MixinTypes)
                 c.BaseTypes.Add("I" + mixin.ClrName);
 
-            c.Comments.Add(new CodeCommentStatement($"Content Type {typeModel.Id} with alias \"{typeModel.Alias}\""));
+            c.Comments.Add(new CodeCommentStatement($"Content type with alias \"{typeModel.Alias}\""));
 
             foreach (var propertyModel in typeModel.Properties)
             {

--- a/Umbraco.ModelsBuilder/Building/TextBuilder.cs
+++ b/Umbraco.ModelsBuilder/Building/TextBuilder.cs
@@ -105,7 +105,7 @@ namespace Umbraco.ModelsBuilder.Building
             if (type.IsMixin)
             {
                 // write the interface declaration
-                sb.AppendFormat("\t// Mixin content Type {0} with alias \"{1}\"\n", type.Id, type.Alias);
+                sb.AppendFormat("\t// Mixin content type with alias \"{0}\"\n", type.Alias);
                 if (!string.IsNullOrWhiteSpace(type.Name))
                     sb.AppendFormat("\t/// <summary>{0}</summary>\n", XmlCommentString(type.Name));
                 sb.AppendFormat("\tpublic partial interface I{0}", type.ClrName);
@@ -139,7 +139,7 @@ namespace Umbraco.ModelsBuilder.Building
 
             // write the class declaration
             if (type.IsRenamed)
-                sb.AppendFormat("\t// Content Type {0} with alias \"{1}\"\n", type.Id, type.Alias);
+                sb.AppendFormat("\t// Content type with alias \"{0}\"\n", type.Alias);
             if (!string.IsNullOrWhiteSpace(type.Name))
                 sb.AppendFormat("\t/// <summary>{0}</summary>\n", XmlCommentString(type.Name));
             // cannot do it now. see note in ImplementContentTypeAttribute
@@ -439,9 +439,8 @@ namespace Umbraco.ModelsBuilder.Building
 
         private void WriteNonGenericClrType(StringBuilder sb, string s)
         {
-
             // takes care eg of "System.Int32" vs. "int"
-            if (TypesMap.TryGetValue(s.ToLowerInvariant(), out string typeName))
+            if (TypesMap.TryGetValue(s, out string typeName))
             {
                 sb.Append(typeName);
                 return;
@@ -511,24 +510,24 @@ namespace Umbraco.ModelsBuilder.Building
             return s.Replace('<', '{').Replace('>', '}').Replace('\r', ' ').Replace('\n', ' ');
         }
 
-        private static readonly IDictionary<string, string> TypesMap = new Dictionary<string, string>
+        private static readonly IDictionary<string, string> TypesMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            { "system.int16", "short" },
-            { "system.int32", "int" },
-            { "system.int64", "long" },
-            { "system.string", "string" },
-            { "system.object", "object" },
-            { "system.boolean", "bool" },
-            { "system.void", "void" },
-            { "system.char", "char" },
-            { "system.byte", "byte" },
-            { "system.uint16", "ushort" },
-            { "system.uint32", "uint" },
-            { "system.uint64", "ulong" },
-            { "system.sbyte", "sbyte" },
-            { "system.single", "float" },
-            { "system.double", "double" },
-            { "system.decimal", "decimal" }
+            { "System.Int16", "short" },
+            { "System.Int32", "int" },
+            { "System.Int64", "long" },
+            { "System.String", "string" },
+            { "System.Object", "object" },
+            { "System.Boolean", "bool" },
+            { "System.Void", "void" },
+            { "System.Char", "char" },
+            { "System.Byte", "byte" },
+            { "System.UInt16", "ushort" },
+            { "System.UInt32", "uint" },
+            { "System.UInt64", "ulong" },
+            { "System.SByte", "sbyte" },
+            { "System.Single", "float" },
+            { "System.Double", "double" },
+            { "System.Decimal", "decimal" }
         };
     }
 }


### PR DESCRIPTION
This should fix issue #173. Because the UDI isn't available on the `TypeModel`, I've just removed the ID for now...

I also made the `TypesMap` dictionary case insensitive, so it doesn't have to call `ToLowerInvariant()` on every key lookup!