### PR TITLE
Version 3.1.1: limit Microsoft.CodeAnalysis.CSharp to version 2.10 >= x < 3.0

### DIFF
--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -28,12 +28,12 @@ using System.Runtime.InteropServices;
 // Also need to
 
 // Assembly
-[assembly: AssemblyVersion("3.1.0.103")]
-[assembly: AssemblyFileVersion("3.1.0.103")]
+[assembly: AssemblyVersion("3.1.1.104")]
+[assembly: AssemblyFileVersion("3.1.1.104")]
 
 // NuGet Package
 // Note: could not release "1.8.0" because it was depending on pre-release NuGet packages
 //  for Roslyn, so had to release 1.8.0-final... starting with 2.1.3 Roslyn has a released
 //  1.0 version, so now we can release "2.1.3" without the "-final" extension.
-[assembly: AssemblyInformationalVersion("3.1.0.103")]
+[assembly: AssemblyInformationalVersion("3.1.1.104")]
 // Do not remove this line.

--- a/Umbraco.ModelsBuilder.CustomTool/source.extension.vsixmanifest
+++ b/Umbraco.ModelsBuilder.CustomTool/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="F5C32FC3-6672-4665-803D-6C5D2CAC556A" Version="3.1.0.103" Language="en-US" Publisher="Umbraco HQ" />
+    <Identity Id="F5C32FC3-6672-4665-803D-6C5D2CAC556A" Version="3.1.1.104" Language="en-US" Publisher="Umbraco HQ" />
     <DisplayName>Umbraco ModelsBuilder Custom Tool</DisplayName>
     <Description xml:space="preserve">Umbraco Visual Studio Custom Tool for generating strongly typed IPublishedContent models.</Description>
     <MoreInfo>https://github.com/zpqrtbnk/Zbu.ModelsBuilder</MoreInfo>

--- a/build/Nuspecs/ModelsBuilder/Umbraco.ModelsBuilder.nuspec
+++ b/build/Nuspecs/ModelsBuilder/Umbraco.ModelsBuilder.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
-	<metadata minClientVersion="2.8.1">
+  <metadata minClientVersion="2.8.1">
     <id>Umbraco.ModelsBuilder</id>
     <version>$version$</version>
     <title>Umbraco ModelsBuilder</title>
@@ -15,10 +15,10 @@
     <language>en-US</language>
     <tags>umbraco</tags>
     <dependencies>
-			<dependency id="Microsoft.CodeAnalysis.CSharp" version="2.10.0" />
+      <dependency id="Microsoft.CodeAnalysis.CSharp" version="[2.10.0,3)" />
     </dependencies>
-	</metadata>
-	<files>
+  </metadata>
+  <files>
     <!-- our dlls -->
     <file src="Umbraco.ModelsBuilder.dll" target="lib\Umbraco.ModelsBuilder.dll" />
     <file src="Umbraco.ModelsBuilder.pdb" target="lib\Umbraco.ModelsBuilder.pdb" />


### PR DESCRIPTION
This fixes issue #196 by limiting the `Microsoft.CodeAnalysis.CSharp` dependency version to 2.10 >= x < 3.0 for the latest ModelsBuilder (3.1.0). The fix for version 3.0.10 is available here: https://github.com/ronaldbarendse/Zbu.ModelsBuilder/tree/temp-196