### PR TITLE
GetModelContentType: throw exception when no UmbracoContext exists

### DIFF
--- a/src/Umbraco.ModelsBuilder/Umbraco/PublishedModelUtility.cs
+++ b/src/Umbraco.ModelsBuilder/Umbraco/PublishedModelUtility.cs
@@ -26,15 +26,18 @@ namespace Umbraco.ModelsBuilder.Umbraco
 
         public static IPublishedContentType GetModelContentType(PublishedItemType itemType, string alias)
         {
-            var facade = Current.UmbracoContext.PublishedSnapshot; // fixme inject!
+            var umbracoContext = Current.UmbracoContext;
+            if (umbracoContext == null) throw new InvalidOperationException("This method requires an UmbracoContext, ensure this is created using IUmbracoContextFactory.EnsureUmbracoContext().");
+
+            var publishedSnapshot = umbracoContext.PublishedSnapshot;
             switch (itemType)
             {
                 case PublishedItemType.Content:
-                    return facade.Content.GetContentType(alias);
+                    return publishedSnapshot.Content.GetContentType(alias);
                 case PublishedItemType.Media:
-                    return facade.Media.GetContentType(alias);
+                    return publishedSnapshot.Media.GetContentType(alias);
                 case PublishedItemType.Member:
-                    return facade.Members.GetContentType(alias);
+                    return publishedSnapshot.Members.GetContentType(alias);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(itemType));
             }


### PR DESCRIPTION
This 'fixes' issue https://github.com/zpqrtbnk/Zbu.ModelsBuilder/issues/222 and should be able to get merged with PR https://github.com/zpqrtbnk/Zbu.ModelsBuilder/pull/223.

Instead of throwing an `ArgumentNullException`, this method now throws an `InvalidOperationException` indicating it requires an `UmbracoContext` to be present.

To make it all work, callers should ensure this using `IUmbracoContextFactory.EnsureUmbracoContext()` as described in https://github.com/zpqrtbnk/Zbu.ModelsBuilder/issues/222#issuecomment-538320942.

If you only need the property alias, the new `GetModelPropertyTypeAlias` method from PR https://github.com/zpqrtbnk/Zbu.ModelsBuilder/pull/223#issuecomment-538384680 doesn't require the `UmbracoContext`.