### PR TITLE
Add XML comments to public members (resolves CS1591 warnings)

### DIFF
--- a/src/Umbraco.ModelsBuilder/Building/TextBuilder.cs
+++ b/src/Umbraco.ModelsBuilder/Building/TextBuilder.cs
@@ -195,16 +195,20 @@ namespace Umbraco.ModelsBuilder.Building
             // as 'new' since parent has its own - or maybe not - disable warning
             sb.Append("\t\t// helpers\n");
             sb.Append("#pragma warning disable 0109 // new is redundant\n");
+            sb.AppendFormat("\t\t/// <summary>{0}</summary>\n", XmlCommentString("The alias of the model type."));
             WriteGeneratedCodeAttribute(sb, "\t\t");
             sb.AppendFormat("\t\tpublic new const string ModelTypeAlias = \"{0}\";\n",
                 type.Alias);
             var itemType = type.IsElement ? TypeModel.ItemTypes.Content : type.ItemType; // fixme
+            sb.AppendFormat("\t\t/// <summary>{0}</summary>\n", XmlCommentString("The <see cref=\"PublishedItemType\"/> this model represents."));
             WriteGeneratedCodeAttribute(sb, "\t\t");
             sb.AppendFormat("\t\tpublic new const PublishedItemType ModelItemType = PublishedItemType.{0};\n",
                 itemType);
+            sb.AppendFormat("\t\t/// <summary>{0}</summary>\n", XmlCommentString("Gets the <see cref=\"IPublishedContentType\"/> of the model type."));
             WriteGeneratedCodeAttribute(sb, "\t\t");
             sb.Append("\t\tpublic new static IPublishedContentType GetModelContentType()\n");
             sb.Append("\t\t\t=> PublishedModelUtility.GetModelContentType(ModelItemType, ModelTypeAlias);\n");
+            sb.AppendFormat("\t\t/// <summary>{0}</summary>\n", XmlCommentString("Gets the <see cref=\"IPublishedPropertyType\"/> for a model property based on the provided expression."));
             WriteGeneratedCodeAttribute(sb, "\t\t");
             sb.AppendFormat("\t\tpublic static IPublishedPropertyType GetModelPropertyType<TValue>(Expression<Func<{0}, TValue>> selector)\n",
                 type.ClrName);
@@ -213,7 +217,7 @@ namespace Umbraco.ModelsBuilder.Building
 
             // write the ctor
             if (!type.HasCtor)
-                sb.AppendFormat("\t\t// ctor\n\t\tpublic {0}(IPublished{1} content)\n\t\t\t: base(content)\n\t\t{{ }}\n\n",
+                sb.AppendFormat("\t\t// ctor\n\t\t/// <inheritdoc />\n\t\tpublic {0}(IPublished{1} content)\n\t\t\t: base(content)\n\t\t{{ }}\n\n",
                     type.ClrName, type.IsElement ? "Element" : "Content");
 
             // write the properties


### PR DESCRIPTION
When XML documentation is enabled for the project (see screenshot below), the CS1591 compiler warning means that any public members of classes must have a documentation comment to prevent a warning.

![image](https://user-images.githubusercontent.com/899202/67198896-dce55700-f3f7-11e9-8f41-d3e36f6256c9.png)

There's currently no way to disable this documentation requirement for generated code so there seems to be no workaround for this issue - see https://github.com/dotnet/roslyn/issues/12702.

This PR adds `<summary>` comments to the previously uncommented public members of the generated models classes. An alternative approach could be to add `#pragma warning disable 1591` comments around these members, but it seemed just as easy to add a simple documentation comment. Resolves #164 