### PR TITLE
Generate code using language fallback

### DIFF
--- a/src/Umbraco.ModelsBuilder/Building/PropertyModel.cs
+++ b/src/Umbraco.ModelsBuilder/Building/PropertyModel.cs
@@ -47,6 +47,11 @@ namespace Umbraco.ModelsBuilder.Building
         public bool IsIgnored;
 
         /// <summary>
+        /// Gets a value indicating whether this property allows varying by Culture.
+        /// </summary>
+        public bool IsCultureVariant;
+
+        /// <summary>
         /// Gets the generation errors for the property.
         /// </summary>
         /// <remarks>This should be null, unless something prevents the property from being

--- a/src/Umbraco.ModelsBuilder/Building/TextBuilder.cs
+++ b/src/Umbraco.ModelsBuilder/Building/TextBuilder.cs
@@ -344,8 +344,16 @@ namespace Umbraco.ModelsBuilder.Building
                     WriteClrType(sb, property.ClrTypeName);
                     sb.Append(">");
                 }
-                sb.AppendFormat("(\"{0}\");\n",
-                    property.Alias);
+                if (property.IsCultureVariant && Config.RenderLanguageFallback)
+                {
+                    sb.AppendFormat("(\"{0}\", fallback: Fallback.ToLanguage);\n",
+                        property.Alias);
+                }
+                else
+                {
+                    sb.AppendFormat("(\"{0}\");\n",
+                        property.Alias);
+                }
             }
 
             if (property.Errors != null)
@@ -377,8 +385,16 @@ namespace Umbraco.ModelsBuilder.Building
                 WriteClrType(sb, property.ClrTypeName);
                 sb.Append(">");
             }
-            sb.AppendFormat("(\"{0}\");\n",
-                property.Alias);
+            if (property.IsCultureVariant && Config.RenderLanguageFallback)
+            {
+                sb.AppendFormat("(\"{0}\", fallback: Fallback.ToLanguage);\n",
+                    property.Alias);
+            }
+            else
+            {
+                sb.AppendFormat("(\"{0}\");\n",
+                    property.Alias);
+            }
         }
 
         private static IEnumerable<string> SplitError(string error)

--- a/src/Umbraco.ModelsBuilder/Configuration/Config.cs
+++ b/src/Umbraco.ModelsBuilder/Configuration/Config.cs
@@ -76,6 +76,7 @@ namespace Umbraco.ModelsBuilder.Configuration
 
             // default: false
             EnableApi = ConfigurationManager.AppSettings[prefix + "EnableApi"].InvariantEquals("true");
+            RenderLanguageFallback = ConfigurationManager.AppSettings[prefix + "RenderLanguageFallback"].InvariantEquals("true");
             AcceptUnsafeModelsDirectory = ConfigurationManager.AppSettings[prefix + "AcceptUnsafeModelsDirectory"].InvariantEquals("true");
 
             // default: true
@@ -163,6 +164,7 @@ namespace Umbraco.ModelsBuilder.Configuration
             bool enable = false,
             ModelsMode modelsMode = ModelsMode.Nothing,
             bool enableApi = true,
+            bool renderLanguageFallback = false,
             string modelsNamespace = null,
             bool enableFactory = true,
             LanguageVersion languageVersion = DefaultLanguageVersion,
@@ -178,6 +180,7 @@ namespace Umbraco.ModelsBuilder.Configuration
             ModelsMode = modelsMode;
 
             EnableApi = enableApi;
+            RenderLanguageFallback = renderLanguageFallback;
             ModelsNamespace = string.IsNullOrWhiteSpace(modelsNamespace) ? DefaultModelsNamespace : modelsNamespace;
             EnableFactory = enableFactory;
             LanguageVersion = languageVersion;
@@ -249,6 +252,14 @@ namespace Umbraco.ModelsBuilder.Configuration
         ///     and retrieve the content types. It needs to be enabled so the extension & tool can work.</para>
         /// </remarks>
         public bool EnableApi { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the generated code adds language fallback on variant properties.
+        /// </summary>
+        /// <remarks>
+        ///     <para>Default value is <c>false</c>.</para>
+        /// </remarks>
+        public bool RenderLanguageFallback { get; }
 
         /// <summary>
         /// Gets a value indicating whether the API is installed.

--- a/src/Umbraco.ModelsBuilder/Umbraco/UmbracoServices.cs
+++ b/src/Umbraco.ModelsBuilder/Umbraco/UmbracoServices.cs
@@ -154,7 +154,9 @@ namespace Umbraco.ModelsBuilder.Umbraco
                         ClrName = GetClrName(propertyType.Name, propertyType.Alias),
 
                         Name = propertyType.Name,
-                        Description = propertyType.Description
+                        Description = propertyType.Description,
+
+                        IsCultureVariant = propertyType.Variations == ContentVariation.Culture
                     };
 
                     var publishedPropertyType = publishedContentType.GetPropertyType(propertyType.Alias);


### PR DESCRIPTION
- Added appSetting to enable generation of language fallback
- Added property on PropertyModel to indicate Variant property
- Added fallback parameter to this.Value<>() for Variant properties, when appSetting is true