### PR TITLE
v4: Add possibility of set custom assembly name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ build.tmp/
 build.out/
 
 # eof
+src/.idea

--- a/src/Our.ModelsBuilder/Building/CodeModel.cs
+++ b/src/Our.ModelsBuilder/Building/CodeModel.cs
@@ -59,6 +59,20 @@ namespace Our.ModelsBuilder.Building
         /// </summary>
         // TODO: per-model namespace
         public string ModelsNamespace { get; set; }
+        public string CustomAssemblyName { get; set; }
+
+        public string AssemblyName
+        {
+            get
+            {
+                if (CustomAssemblyName != null)
+                {
+                    return CustomAssemblyName;
+                }
+
+                return ModelsNamespace;
+            }
+        }
 
         public ISet<string> Using { get; set; } = new HashSet<string>();
 

--- a/src/Our.ModelsBuilder/Building/CodeModel.cs
+++ b/src/Our.ModelsBuilder/Building/CodeModel.cs
@@ -59,8 +59,16 @@ namespace Our.ModelsBuilder.Building
         /// </summary>
         // TODO: per-model namespace
         public string ModelsNamespace { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the models assembly name.
+        /// </summary>
+        // TODO: per-model assembly name
         public string CustomAssemblyName { get; set; }
-
+        
+        /// <summary>
+        /// Gets models assembly name or fallback to the models namespace
+        /// </summary>
         public string AssemblyName
         {
             get

--- a/src/Our.ModelsBuilder/Building/CodeModelBuilder.cs
+++ b/src/Our.ModelsBuilder/Building/CodeModelBuilder.cs
@@ -63,6 +63,7 @@ namespace Our.ModelsBuilder.Building
             var model = new CodeModel(data, Options.LanguageVersion)
             {
                 ModelsNamespace = GetModelsNamespace(), 
+                CustomAssemblyName = GetAssemblyName(),
                 Using = GetUsing()
             };
 
@@ -72,6 +73,20 @@ namespace Our.ModelsBuilder.Building
 
             return model;
         }
+        public virtual string GetAssemblyName()
+        {
+            // use namespace from code options... or from options
+            var modelsNamespace = CodeOptions.HasCustomAssemblyName
+                ? CodeOptions.CustomAssemblyName
+                : Options.AssemblyName;
+
+            // otherwise, use const
+            if (string.IsNullOrWhiteSpace(modelsNamespace))
+                modelsNamespace = GetDefaultAssemblyName();
+
+            return modelsNamespace;
+        }
+        public virtual string GetDefaultAssemblyName() => null;
 
         protected virtual string GetDefaultModelsNamespace() => "Umbraco.Web.PublishedModels";
 

--- a/src/Our.ModelsBuilder/Building/Generator.cs
+++ b/src/Our.ModelsBuilder/Building/Generator.cs
@@ -54,7 +54,7 @@ namespace Our.ModelsBuilder.Building
                     files[file] = File.ReadAllText(file);
                 var compiler = new Compiler(_options.LanguageVersion);
                 // FIXME what is the name of the DLL as soon as we accept several namespaces = an option?
-                compiler.Compile(codeModel.ModelsNamespace, files, bin);
+                compiler.Compile(codeModel.AssemblyName, files, bin);
             }
 
             OutOfDateModelsStatus.Clear();

--- a/src/Our.ModelsBuilder/Options/CodeOptions.cs
+++ b/src/Our.ModelsBuilder/Options/CodeOptions.cs
@@ -32,12 +32,12 @@ namespace Our.ModelsBuilder.Options
         /// </summary>
         public string ModelsNamespace { get; internal set; }
         /// <summary>
-        /// Gets a value indicating whether a models namespace has been specified.
+        /// Gets a value indicating whether a Custom assembly name has been specified.
         /// </summary>
         public bool HasCustomAssemblyName => !string.IsNullOrWhiteSpace(CustomAssemblyName);
 
         /// <summary>
-        /// Gets the models namespace.
+        /// Gets the models assembly name.
         /// </summary>
         public string CustomAssemblyName { get; internal set; }
     }

--- a/src/Our.ModelsBuilder/Options/CodeOptions.cs
+++ b/src/Our.ModelsBuilder/Options/CodeOptions.cs
@@ -31,5 +31,14 @@ namespace Our.ModelsBuilder.Options
         /// Gets the models namespace.
         /// </summary>
         public string ModelsNamespace { get; internal set; }
+        /// <summary>
+        /// Gets a value indicating whether a models namespace has been specified.
+        /// </summary>
+        public bool HasCustomAssemblyName => !string.IsNullOrWhiteSpace(CustomAssemblyName);
+
+        /// <summary>
+        /// Gets the models namespace.
+        /// </summary>
+        public string CustomAssemblyName { get; internal set; }
     }
 }

--- a/src/Our.ModelsBuilder/Options/CodeOptionsBuilder.cs
+++ b/src/Our.ModelsBuilder/Options/CodeOptionsBuilder.cs
@@ -49,10 +49,9 @@ namespace Our.ModelsBuilder.Options
         /// Sets the assembly name.
         /// </summary>
         /// <param name="modelsNamespace">The models namespace.</param>
-        public virtual void SetAssemblyNamespace(string assemblyName)
+        public virtual void SetAssemblyName(string assemblyName)
         {
             CodeOptions.CustomAssemblyName = assemblyName;
         }
     }
     }
-}

--- a/src/Our.ModelsBuilder/Options/CodeOptionsBuilder.cs
+++ b/src/Our.ModelsBuilder/Options/CodeOptionsBuilder.cs
@@ -45,5 +45,14 @@ namespace Our.ModelsBuilder.Options
         {
             CodeOptions.ModelsNamespace = modelsNamespace;
         }
+        /// <summary>
+        /// Sets the assembly name.
+        /// </summary>
+        /// <param name="modelsNamespace">The models namespace.</param>
+        public virtual void SetAssemblyNamespace(string assemblyName)
+        {
+            CodeOptions.CustomAssemblyName = assemblyName;
+        }
+    }
     }
 }

--- a/src/Our.ModelsBuilder/Options/ModelsBuilderOptions.cs
+++ b/src/Our.ModelsBuilder/Options/ModelsBuilderOptions.cs
@@ -61,7 +61,7 @@ namespace Our.ModelsBuilder.Options
         /// </summary>
         /// <remarks>That value could be overriden by other (attribute in user's code...). Return default if no value was supplied.</remarks>
         public string ModelsNamespace { get; set; } = Defaults.ModelsNamespace;
-
+        public string AssemblyName { get; set; } = Defaults.ModelsNamespace;
         /// <summary>
         /// Gets the Roslyn parser language version.
         /// </summary>


### PR DESCRIPTION
Hi Stephan,
As I was playing little with v4 models builder, I noticed it would be helpfull in few cases to setup custom asssembly name, as namespace not always fit the assembly name.
I tried to make changes in manner of supporting both approaches and by default falling back to namespace.