### PR TITLE
support IPublishedElement

### DIFF
--- a/src/Umbraco.ModelsBuilder/Building/CodeParser.cs
+++ b/src/Umbraco.ModelsBuilder/Building/CodeParser.cs
@@ -78,7 +78,10 @@ namespace Umbraco.ModelsBuilder.Building
                         if (x.Parameters.Length != 1) return false;
                         var type1 = x.Parameters[0].Type;
                         var type2 = typeof (IPublishedContent);
-                        return type1.ToDisplayString() == type2.FullName;
+                        var type3 = typeof(IPublishedElement);
+                        if (type1.ToDisplayString() == type2.FullName || type1.ToDisplayString() == type3.FullName) return true;
+
+                        return false;
                     });
 
                 if (hasCtor)


### PR DESCRIPTION
fixes https://github.com/modelsbuilder/ModelsBuilder.Original/issues/255

Seems the v8/dev branch is the default for current MB? I couldn't get v4/dev to build at least, and seemed to have a ton of changes on top of release 8.1.6

The small change here prevents MBs auto generated models from generating a constructor on each model build when the element is an IPublishedElement as for example for Blocklist elements.